### PR TITLE
Fix install paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,4 +18,4 @@ pkg_search_module(GLIB REQUIRED glib-2.0)
 add_subdirectory(src)
 
 install(FILES devicelock.conf
-    DESTINATION /usr/share/lipstick/devicelock/)
+    DESTINATION ${SHARE_INSTALL_PREFIX}/lipstick/devicelock/)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,4 +13,4 @@ target_link_libraries(glacier-devicelock
 target_include_directories(glacier-devicelock PRIVATE ${GLIB_INCLUDE_DIRS})
 
 install(TARGETS glacier-devicelock RUNTIME
-	DESTINATION /usr/lib/qt6/plugins/devicelock/)
+	DESTINATION ${LIB_INSTALL_DIR}/qt6/plugins/devicelock/)


### PR DESCRIPTION
Fix install paths so that they're using cmake variables which can be changed to allow install in correct directories for example `/usr/lib64`